### PR TITLE
Refactor IotWebConf, update libraries, disable_status_led config

### DIFF
--- a/measure-station/platformio.ini
+++ b/measure-station/platformio.ini
@@ -8,12 +8,27 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+[env]
+framework = arduino
+monitor_speed = 115200
+
+[common]
+lib_deps = 
+	tobiasschuerg/ESP8266 Influxdb@^3.11.0
+	knolleary/PubSubClient@^2.8
+	beegee-tokyo/DHT sensor library for ESPx@^1.18
+	prampec/IotWebConf@^3.2.0
+
 [env:nodemcuv2]
 platform = espressif8266
 board = nodemcuv2
-framework = arduino
-lib_deps = 
-	tobiasschuerg/ESP8266 Influxdb@^3.6.0
-	knolleary/PubSubClient@^2.8
-	beegee-tokyo/DHT sensor library for ESPx@^1.17
-	https://github.com/prampec/IotWebConf.git
+lib_deps = ${common.lib_deps}
+upload_speed = 921600
+board_build.f_cpu = 80000000L
+
+[env:d1_mini]
+platform = espressif8266
+board = d1_mini
+lib_deps = ${common.lib_deps}
+upload_speed = 921600
+board_build.f_cpu = 80000000L

--- a/measure-station/src/measure-station.cpp
+++ b/measure-station/src/measure-station.cpp
@@ -63,7 +63,7 @@ Influxdb* influx;
 PubSubClient mqtt_client(wifi_client);
 IotWebConf iotWebConf(intial_host_name, &dns_server, &server, initial_pw, CONFIG_VERSION);
 iotwebconf::ParameterGroup settingsGroup = iotwebconf::ParameterGroup("settingsGroup", "Measure Station Settings");
-iotwebconf::TextParameter influxdb_host_param = iotwebconf::TextParameter("InflufDB Host", "influxdb_host", cfg::influxdb_host, STR_LEN);
+iotwebconf::TextParameter influxdb_host_param = iotwebconf::TextParameter("InfluxDB Host", "influxdb_host", cfg::influxdb_host, STR_LEN);
 iotwebconf::TextParameter influxdb_database_param = iotwebconf::TextParameter("InfluxDB Database", "influxdb_database", cfg::influxdb_database, STR_LEN);
 iotwebconf::TextParameter mqtt_server_param = iotwebconf::TextParameter("MQTT Server", "mqtt_server", cfg::mqtt_server, STR_LEN);
 iotwebconf::TextParameter hostname_param = iotwebconf::TextParameter("Node (e.g. the room)", "node", cfg::node, STR_LEN);

--- a/measure-station/src/measure-station.cpp
+++ b/measure-station/src/measure-station.cpp
@@ -5,9 +5,15 @@
 #include <PubSubClient.h>
 #include <InfluxDb.h>
 #include <IotWebConf.h>
-#include <IotWebConfCompatibility.h>
+#include <IotWebConfUsing.h>
+// Include Update server
+#ifdef ESP8266
+# include <ESP8266HTTPUpdateServer.h>
+#elif defined(ESP32)
+# include <IotWebConfESP32HTTPUpdateServer.h>
+#endif
 
-#define CONFIG_VERSION "meaure-station-v1"
+#define CONFIG_VERSION "measure-station-v1.1"
 #define STATUS_PIN LED_BUILTIN
 #define CONFIG_PIN D2
 #define STR_LEN 128
@@ -35,6 +41,9 @@ namespace cfg
   char disable_status_led[NUMBER_LEN];
 }
 
+static char ledStatusValues[][NUMBER_LEN] = { "0", "1" };
+static char ledStatusNames[][STR_LEN] = { "Enabled", "Disabled" };
+
 DHTesp dht;
 TempAndHumidity dht_val;
 float dew_point;
@@ -42,15 +51,25 @@ float dew_point;
 DNSServer dns_server;
 ESP8266WebServer server(80);
 WiFiClient wifi_client;
+
+// Create Update Server
+#ifdef ESP8266
+ESP8266HTTPUpdateServer httpUpdater;
+#elif defined(ESP32)
 HTTPUpdateServer httpUpdater;
+#endif
+
 Influxdb* influx;
 PubSubClient mqtt_client(wifi_client);
 IotWebConf iotWebConf(intial_host_name, &dns_server, &server, initial_pw, CONFIG_VERSION);
-IotWebConfParameter influxdb_host_param = IotWebConfParameter("InflufDB Host", "influxdb_host", cfg::influxdb_host, STR_LEN);
-IotWebConfParameter influxdb_database_param = IotWebConfParameter("InfluxDB Database", "influxdb_database", cfg::influxdb_database, STR_LEN);
-IotWebConfParameter mqtt_server_param = IotWebConfParameter("MQTT Server", "mqtt_server", cfg::mqtt_server, STR_LEN);
-IotWebConfParameter hostname_param = IotWebConfParameter("Node (e.g. the room)", "node", cfg::node, STR_LEN);
-IotWebConfParameter disable_status_led_param = IotWebConfParameter("Disable status LED", "disable_status_led", cfg::disable_status_led, NUMBER_LEN, "number", "0..1", NULL, "min='0' max='1' step='1'");
+iotwebconf::ParameterGroup settingsGroup = iotwebconf::ParameterGroup("settingsGroup", "Measure Station Settings");
+iotwebconf::TextParameter influxdb_host_param = iotwebconf::TextParameter("InflufDB Host", "influxdb_host", cfg::influxdb_host, STR_LEN);
+iotwebconf::TextParameter influxdb_database_param = iotwebconf::TextParameter("InfluxDB Database", "influxdb_database", cfg::influxdb_database, STR_LEN);
+iotwebconf::TextParameter mqtt_server_param = iotwebconf::TextParameter("MQTT Server", "mqtt_server", cfg::mqtt_server, STR_LEN);
+iotwebconf::TextParameter hostname_param = iotwebconf::TextParameter("Node (e.g. the room)", "node", cfg::node, STR_LEN);
+//iotwebconf::NumberParameter disable_status_led_param = iotwebconf::NumberParameter("Disable status LED", "disable_status_led", cfg::disable_status_led, NUMBER_LEN, "number", "0..1", "min='0' max='1' step='1'");
+iotwebconf::SelectParameter disable_status_led_param = iotwebconf::SelectParameter("Status LED", "disable_status_led", cfg::disable_status_led, NUMBER_LEN, (char*)ledStatusValues, (char*)ledStatusNames, sizeof(ledStatusValues) / NUMBER_LEN, STR_LEN);
+
 
 String pub_topic_temp, pub_topic_humid, sub_topic;
 String mqtt_msg;
@@ -234,13 +253,16 @@ void setup()
 
   iotWebConf.setStatusPin(STATUS_PIN);
   iotWebConf.setConfigPin(CONFIG_PIN);
-  iotWebConf.addParameter(&hostname_param);
-  iotWebConf.addParameter(&influxdb_host_param);
-  iotWebConf.addParameter(&influxdb_database_param);
-  iotWebConf.addParameter(&mqtt_server_param);
-  iotWebConf.addParameter(&disable_status_led_param);
+  settingsGroup.addItem(&hostname_param);
+  settingsGroup.addItem(&influxdb_host_param);
+  settingsGroup.addItem(&influxdb_database_param);
+  settingsGroup.addItem(&mqtt_server_param);
+  settingsGroup.addItem(&disable_status_led_param);
+  iotWebConf.addParameterGroup(&settingsGroup);
   iotWebConf.setConfigSavedCallback(&config_saved);
-  iotWebConf.setupUpdateServer(&httpUpdater);
+  iotWebConf.setupUpdateServer(
+    [](const char* updatePath) { httpUpdater.setup(&server, updatePath); },
+    [](const char* userName, char* password) { httpUpdater.updateCredentials(userName, password); });
   iotWebConf.setWifiConnectionCallback(&wifi_connected);
 
   cfg::hostname = iotWebConf.getThingName();
@@ -311,13 +333,13 @@ void loop()
     starttime = millis(); // store the start time
     sensorDHT();          // getting temperature and humidity
     Serial.println("------------------------------");
-    if (iotWebConf.getState() == IOTWEBCONF_STATE_ONLINE)
+    if (iotWebConf.getState() == iotwebconf::OnLine)
       send_data_to_influxdb();
   }
 
   if (cfg::mqtt_server[0] != '\0')
   {
-    if ((iotWebConf.getState() == IOTWEBCONF_STATE_ONLINE) && (!mqtt_client.connected()))
+    if ((iotWebConf.getState() == iotwebconf::OnLine) && (!mqtt_client.connected()))
       reconnect();
     mqtt_client.loop();
   }


### PR DESCRIPTION
Update Libraries & add D1 Mini to platformio file

Refactored IotWebConf (see breaking changes https://github.com/prampec/IotWebConf/blob/master/doc/MigrationGuide-v3.0.0.md )

I changed disable_status_led from a number parameter to select parameter (although have left the refactored number parameter commented out).  I think its more understandable than a user selecting 0 or 1 for led status.

Also bumped config version to v1.1